### PR TITLE
Add support for bash shell.

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Follow the instructions for downloading and installing [Go](https://go.dev/doc/i
 ## Roadmap
 
 - [x] Add zsh parser 
-- [ ] Add bash parser 
+- [x] Add bash parser 
 - [ ] Add fish parser
 - [ ] Enhance output format (open to creative ideas!) 
 

--- a/config/env.go
+++ b/config/env.go
@@ -22,6 +22,8 @@ func ParseEnv(config *Config) error {
 	switch shellName {
 	case "zsh":
 		config.HistoryPath = home + "/.zsh_history"
+	case "bash":
+		config.HistoryPath = home + "/.bash_history"
 	case "":
 		return fmt.Errorf("can't parse %s environment variable value", shellKey)
 	default:

--- a/history/bash_parser.go
+++ b/history/bash_parser.go
@@ -1,0 +1,43 @@
+package history
+
+import (
+	"bufio"
+	"log"
+	"os"
+	"strings"
+
+	"github.com/quentinlintz/cmdtop/models"
+)
+
+type BashParser struct{}
+
+func (p *BashParser) ParseHistory(filepath string) ([]models.Command, error) {
+	file, err := os.Open(filepath)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	commandMap := make(map[string]int)
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		parts := strings.Split(scanner.Text(), " ")
+		command := parts[0]
+		if len(command) > 0 {
+			commandMap[command]++
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+
+	var commands []models.Command
+	for name, count := range commandMap {
+		commands = append(commands, models.Command{Name: name, Count: count})
+	}
+
+	log.Printf("commands: %#v", commands)
+
+	return commands, nil
+}

--- a/history/bash_parser.go
+++ b/history/bash_parser.go
@@ -2,7 +2,6 @@ package history
 
 import (
 	"bufio"
-	"log"
 	"os"
 	"strings"
 
@@ -36,8 +35,6 @@ func (p *BashParser) ParseHistory(filepath string) ([]models.Command, error) {
 	for name, count := range commandMap {
 		commands = append(commands, models.Command{Name: name, Count: count})
 	}
-
-	log.Printf("commands: %#v", commands)
 
 	return commands, nil
 }

--- a/history/parser.go
+++ b/history/parser.go
@@ -21,6 +21,8 @@ func PrintTopCommands(cfg config.Config, p Parser) {
 		log.Fatalf("Error parsing history: %v", err)
 	}
 
+	log.Printf("commands in PrintTopCommands: %#v", commands)
+
 	sort.Slice(commands, func(i, j int) bool {
 		return commands[i].Count > commands[j].Count
 	})

--- a/history/parser.go
+++ b/history/parser.go
@@ -21,8 +21,6 @@ func PrintTopCommands(cfg config.Config, p Parser) {
 		log.Fatalf("Error parsing history: %v", err)
 	}
 
-	log.Printf("commands in PrintTopCommands: %#v", commands)
-
 	sort.Slice(commands, func(i, j int) bool {
 		return commands[i].Count > commands[j].Count
 	})

--- a/history/parser_test.go
+++ b/history/parser_test.go
@@ -21,6 +21,7 @@ func TestParseHistory(t *testing.T) {
 		historyFile string
 	}{
 		{"Zsh", &ZshParser{}, "zsh_history"},
+		{"Bash", &BashParser{}, "bash_history"},
 	}
 
 	for _, tt := range tests {
@@ -37,6 +38,7 @@ func TestHistoryFileNotFound(t *testing.T) {
 		parser Parser
 	}{
 		{"Zsh", &ZshParser{}},
+		{"Bash", &BashParser{}},
 	}
 
 	for _, tt := range tests {

--- a/history/testdata/bash_history
+++ b/history/testdata/bash_history
@@ -1,0 +1,5 @@
+ls -la
+cd /home
+git status
+ls -la
+git commit -m "Initial commit"

--- a/main.go
+++ b/main.go
@@ -56,6 +56,12 @@ func main() {
 	}
 
 	var p history.Parser
-	p = &history.ZshParser{}
+	switch cfg.ShellType {
+	case "zsh":
+		p = &history.ZshParser{}
+	case "bash":
+		p = &history.BashParser{}
+	}
+
 	history.PrintTopCommands(cfg, p)
 }


### PR DESCRIPTION
Add basic command parser for bash history file

Add switch in main.go that checks for the shell type set in config and runs shell-specific parser for each case.